### PR TITLE
RoundRobin: Allocate equal number of cores from each socket.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
                 .long("thread-mapping")
                 .short("t")
                 .takes_value(true)
-                .possible_values(&["sequential", "interleave"])
+                .possible_values(&["sequential", "interleave", "roundrobin"])
                 .help("Do you want to interleave over sockets or allocate sequential"),
         )
         .arg(
@@ -40,6 +40,7 @@ fn main() {
     let thread_mapping = match matches.value_of("tm").unwrap_or("interleave") {
         "interleave" => ThreadMapping::Interleave,
         "sequential" => ThreadMapping::Sequential,
+        "roundrobin" => ThreadMapping::RoundRobin,
         _ => unreachable!(),
     };
     let mt = MachineTopology::new();

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -228,6 +228,9 @@ impl MachineTopology {
                 // Allocate 1 or a muliple of number of sockets.
                 if how_many != 1 {
                     assert!(how_many % num_sockets == 0);
+                } else {
+                    c.push(cpus[0]);
+                    return c;
                 }
                 let per_socket = how_many / num_sockets;
                 for socket in &sockets {


### PR DESCRIPTION
All cores from a node follow all the cores from another node.